### PR TITLE
Package dependency pins & test

### DIFF
--- a/.github/workflows/python-tilledbsoma-ml-compat.yml
+++ b/.github/workflows/python-tilledbsoma-ml-compat.yml
@@ -1,0 +1,44 @@
+name: python-tiledbsoma-ml past tiledbsoma compat # Latest tiledbsoma version covered by another workflow
+
+on:
+  pull_request:
+    branches: ["*"]
+    paths-ignore:
+      - "scripts/**"
+  push:
+    branches: [main]
+    paths-ignore:
+      - "scripts/**"
+
+jobs:
+  unit_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        tiledbsoma-version:
+          - "~=1.9.0"
+          - "~=1.10.0"
+          - "~=1.11.0"
+          - "~=1.12.0"
+          - "~=1.13.0"
+          - "~=1.14.0"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install prereqs
+        run: |
+          pip install --upgrade pip pytest setuptools
+          pip install tiledbsoma=${{ tiledbsoma-version }} .
+
+      - name: Run tests
+        run: pytest -v tests

--- a/.github/workflows/python-tilledbsoma-ml-compat.yml
+++ b/.github/workflows/python-tilledbsoma-ml-compat.yml
@@ -5,18 +5,20 @@ on:
     branches: ["*"]
     paths-ignore:
       - "scripts/**"
+      - "notebooks/**"
   push:
     branches: [main]
     paths-ignore:
       - "scripts/**"
+      - "notebooks/**"
 
 jobs:
   unit_tests:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        os: ["ubuntu-latest"]  # could add 'macos-latest', but the matrix is already huge...
+        python-version: ["3.9", "3.10", "3.11"]  # TODO: add 3.12 when tiledbsoma releases wheels for it.
         pkg-version:
           - "tiledbsoma~=1.9.0 'numpy<2.0.0'"
           - "tiledbsoma~=1.10.0 'numpy<2.0.0'"
@@ -24,9 +26,6 @@ jobs:
           - "tiledbsoma~=1.12.0"
           - "tiledbsoma~=1.13.0"
           - "tiledbsoma~=1.14.0"
-        exclude: # TODO: remove mac-os/3.12 exclusion when tiledbsoma supports it
-          - python-version: 3.12
-            os: macos-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/python-tilledbsoma-ml-compat.yml
+++ b/.github/workflows/python-tilledbsoma-ml-compat.yml
@@ -18,8 +18,8 @@ jobs:
         os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         pkg-version:
-          - "tiledbsoma~=1.9.0 numpy<=2.0.0"
-          - "tiledbsoma~=1.10.0 numpy<=2.0.0"
+          - "tiledbsoma~=1.9.0 'numpy<=2.0.0'"
+          - "tiledbsoma~=1.10.0 'numpy<=2.0.0'"
           - "tiledbsoma~=1.11.0"
           - "tiledbsoma~=1.12.0"
           - "tiledbsoma~=1.13.0"

--- a/.github/workflows/python-tilledbsoma-ml-compat.yml
+++ b/.github/workflows/python-tilledbsoma-ml-compat.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install prereqs
         run: |
           pip install --upgrade pip pytest setuptools
-          pip install tiledbsoma=${{ tiledbsoma-version }} .
+          pip install tiledbsoma=${{ matrix.tiledbsoma-version }} .
 
       - name: Run tests
         run: pytest -v tests

--- a/.github/workflows/python-tilledbsoma-ml-compat.yml
+++ b/.github/workflows/python-tilledbsoma-ml-compat.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install prereqs
         run: |
           pip install --upgrade pip pytest setuptools
-          pip install tiledbsoma=${{ matrix.tiledbsoma-version }} .
+          pip install tiledbsoma${{ matrix.tiledbsoma-version }} .
 
       - name: Run tests
         run: pytest -v tests

--- a/.github/workflows/python-tilledbsoma-ml-compat.yml
+++ b/.github/workflows/python-tilledbsoma-ml-compat.yml
@@ -17,13 +17,16 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        tiledbsoma-version:
-          - "~=1.9.0"
-          - "~=1.10.0"
-          - "~=1.11.0"
-          - "~=1.12.0"
-          - "~=1.13.0"
-          - "~=1.14.0"
+        pkg-version:
+          - "tiledbsoma~=1.9.0 numpy<=2.0.0"
+          - "tiledbsoma~=1.10.0 numpy<=2.0.0"
+          - "tiledbsoma~=1.11.0"
+          - "tiledbsoma~=1.12.0"
+          - "tiledbsoma~=1.13.0"
+          - "tiledbsoma~=1.14.0"
+        exclude: # TODO: remove mac-os/3.12 exclusion when tiledbsoma supports it
+          - python-version: 3.12
+            os: macos-latest
 
     runs-on: ${{ matrix.os }}
 
@@ -38,7 +41,7 @@ jobs:
       - name: Install prereqs
         run: |
           pip install --upgrade pip pytest setuptools
-          pip install tiledbsoma${{ matrix.tiledbsoma-version }} .
+          pip install ${{ matrix.pkg-version }} .
 
       - name: Run tests
         run: pytest -v tests

--- a/.github/workflows/python-tilledbsoma-ml-compat.yml
+++ b/.github/workflows/python-tilledbsoma-ml-compat.yml
@@ -18,8 +18,8 @@ jobs:
         os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         pkg-version:
-          - "tiledbsoma~=1.9.0 'numpy<=2.0.0'"
-          - "tiledbsoma~=1.10.0 'numpy<=2.0.0'"
+          - "tiledbsoma~=1.9.0 'numpy<2.0.0'"
+          - "tiledbsoma~=1.10.0 'numpy<2.0.0'"
           - "tiledbsoma~=1.11.0"
           - "tiledbsoma~=1.12.0"
           - "tiledbsoma~=1.13.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - yyyy-mm-dd
 
-Porting and enhancing initial code contribution from the Chan Zuckerberg Initiative Foundation  
+Port and enhance contribution from the Chan Zuckerberg Initiative Foundation
 [CELLxGENE](https://cellxgene.cziscience.com/) project.
+
+This is not a one-for-one migration of the contributed code. Substantial changes have
+been made to the package utility (e.g., multi-GPU support), improve API usability, etc.
 
 ### Added
 
-- Initial commits via PR [#2823](https://github.com/single-cell-data/TileDB-SOMA/pull/2823)
+- Initial commits via [PR #1](https://github.com/single-cell-data/TileDB-SOMA-ML/pull/1)
+- Refine package dependency pins and compatibility tests via [PR #2](https://github.com/single-cell-data/TileDB-SOMA-ML/pull/2)
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "tiledbsoma-ml"
 dynamic = ["version"]
 dependencies = [
-    "attrs",
-    "tiledbsoma",
-    "torch",
+    "attrs>=22.2",
+    "tiledbsoma>=1.9.0",
+    "torch>=2.0",
     "torchdata<=0.9",
     "numpy",
     "numba",


### PR DESCRIPTION
Adds explicit minimum versions for several upstream dependencies, and a GHA workflow to test this.

PR is stacked on the #1 

Because the matrix is quite large, the workflow tests just a subset of it. 