### PR TITLE
add GHA workflows for basic CI (PR 4 of N)

### DIFF
--- a/.github/workflows/python-tiledbsoma-ml.yml
+++ b/.github/workflows/python-tiledbsoma-ml.yml
@@ -1,10 +1,72 @@
-name: python-tiledbsoma-ml
+name: python-tiledbsoma-ml CI
 
 on:
+  pull_request:
+    branches: ["*"]
+    paths-ignore:
+      - 'scripts/**'
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'scripts/**'
+
   workflow_dispatch:
 
 jobs:
-  job:
+  lint:
     runs-on: ubuntu-latest
     steps:
-    # Empty job; placeholder GHA
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Restore pre-commit cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Install pre-commit
+        run: pip -v install pre-commit
+
+      - name: Run pre-commit hooks on all files
+        run: pre-commit run -v -a
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install prereqs
+        run: |
+          pip install --upgrade pip wheel pytest pytest-cov setuptools
+          pip install .
+
+      - name: Run tests
+        run: pytest -v --cov=src --cov-report=xml tests
+
+  build:
+    # for now, just do a test build to ensure that it works
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Do build
+        run: |
+          pip install --upgrade build pip wheel setuptools setuptools-scm
+          python -m build .

--- a/.github/workflows/python-tiledbsoma-ml.yml
+++ b/.github/workflows/python-tiledbsoma-ml.yml
@@ -2,13 +2,11 @@ name: python-tiledbsoma-ml CI
 
 on:
   pull_request:
-    branches: ["*"]
-    paths-ignore:
-      - 'scripts/**'
+    branches: ["**"]
+    paths-ignore: ['scripts/**']
   push:
     branches: [main]
-    paths-ignore:
-      - 'scripts/**'
+    paths-ignore: ['scripts/**']
 
   workflow_dispatch:
 

--- a/.github/workflows/python-tilledbsoma-ml-compat.yml
+++ b/.github/workflows/python-tilledbsoma-ml-compat.yml
@@ -1,0 +1,46 @@
+name: python-tiledbsoma-ml past tiledbsoma compat # Latest tiledbsoma version covered by another workflow
+
+on:
+  pull_request:
+    branches: ["*"]
+    paths-ignore:
+      - "scripts/**"
+      - "notebooks/**"
+  push:
+    branches: [main]
+    paths-ignore:
+      - "scripts/**"
+      - "notebooks/**"
+
+jobs:
+  unit_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]  # could add 'macos-latest', but the matrix is already huge...
+        python-version: ["3.9", "3.10", "3.11"]  # TODO: add 3.12 when tiledbsoma releases wheels for it.
+        pkg-version:
+          - "tiledbsoma~=1.9.0 'numpy<2.0.0'"
+          - "tiledbsoma~=1.10.0 'numpy<2.0.0'"
+          - "tiledbsoma~=1.11.0"
+          - "tiledbsoma~=1.12.0"
+          - "tiledbsoma~=1.13.0"
+          - "tiledbsoma~=1.14.0"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install prereqs
+        run: |
+          pip install --upgrade pip pytest setuptools
+          pip install ${{ matrix.pkg-version }} .
+
+      - name: Run tests
+        run: pytest -v tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: "24.8.0"
     hooks:
       - id: black
-        exclude: 'apis/'
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.5
@@ -11,7 +10,6 @@ repos:
       - id: ruff
         name: "ruff for tiledbsoma_ml"
         args: ["--config=pyproject.toml"]
-        exclude: 'apis/'
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.2
@@ -23,4 +21,3 @@ repos:
           - attrs
           - numpy
           - pandas-stubs>=2
-        exclude: 'apis/'


### PR DESCRIPTION
Changes:
1. add a workflow for the python unit tests and linting
2. add workflow for compatibility test against past versions of tiledbsoma
3. revert the temporary path exclusion in the pre-commit config
