### PR TITLE
CR #6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ show_error_codes = true
 ignore_missing_imports = true
 warn_unreachable = true
 strict = true
-python_version = 3.9
+python_version = '3.11'
 plugins = "numpy.typing.mypy_plugin"
 
 [tool.ruff]
@@ -72,5 +72,5 @@ lint.select = ["E", "F", "B", "I"]
 lint.ignore = ["E501"]  # line too long
 lint.extend-select = ["I001"]  # unsorted-imports
 fix = true
-target-version = "py39"
+target-version = "py311"
 line-length = 120

--- a/src/tiledbsoma_ml/pytorch.py
+++ b/src/tiledbsoma_ml/pytorch.py
@@ -217,10 +217,9 @@ class ExperimentAxisQueryIterable(Iterable[XObsDatum]):
         ].copy()
 
         if logger.isEnabledFor(logging.DEBUG):
+            partition_size = sum([len(chunk) for chunk in obs_partition_joinids])
             logger.debug(
-                f"Process {os.getpid()} rank={rank}, world_size={world_size}, worker_id={worker_id}, "
-                f"n_workers={n_workers}, "
-                f"partition_size={sum([len(chunk) for chunk in obs_partition_joinids])}"
+                f"Process {os.getpid()} {rank=}, {world_size=}, {worker_id=}, n_workers={n_workers}, {partition_size=}"
             )
 
         return iter(obs_partition_joinids)
@@ -280,7 +279,7 @@ class ExperimentAxisQueryIterable(Iterable[XObsDatum]):
         world_size, rank = _get_distributed_world_rank()
         n_workers, worker_id = _get_worker_world_rank()
         logger.debug(
-            f"Iterator created rank={rank}, world_size={world_size}, worker_id={worker_id}, n_workers={n_workers}"
+            f"Iterator created {rank=}, {world_size=}, {worker_id=}, {n_workers=}"
         )
 
         with self.experiment_locator.open_experiment() as exp:


### PR DESCRIPTION
A few changes I accumulated while reading #6 (merging this PR will update #6):
- I don't think we need the dependency on `attrs`; `dataclasses` does what we need, in the stdlib
- Specify 3.11 for pre-commit tools in pyproject.toml (to match GHA)
- Use `SOMA_JOINID` instead of `"soma_joinid"`
- Some suggested type-alias/comment/docstring tweaks

The commits should be relatively self-contained, in case that's an easier way to browse the changes in isolation.

I don't feel strongly about these, happy to discuss!
