### PR TITLE
Type-fixes / errata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,6 @@ version = {attr = "tiledbsoma_ml.__version__"}
 [tool.setuptools.package-data]
 "tiledbsoma_ml" = ["py.typed"]
 
-[tool.setuptools_scm]
-root = "../../.."
-
 [tool.mypy]
 show_error_codes = true
 ignore_missing_imports = true

--- a/src/tiledbsoma_ml/pytorch.py
+++ b/src/tiledbsoma_ml/pytorch.py
@@ -328,15 +328,13 @@ class ExperimentAxisQueryIterable(Iterable[XObsDatum]):
             experimental
         """
 
-        if (
-            self.return_sparse_X
-            and torch.utils.data.get_worker_info()
-            and torch.utils.data.get_worker_info().num_workers > 0
-        ):
-            raise NotImplementedError(
-                "torch does not work with sparse tensors in multi-processing mode "
-                "(see https://github.com/pytorch/pytorch/issues/20248)"
-            )
+        if self.return_sparse_X:
+            worker_info = torch.utils.data.get_worker_info()
+            if worker_info and worker_info.num_workers > 0:
+                raise NotImplementedError(
+                    "torch does not work with sparse tensors in multi-processing mode "
+                    "(see https://github.com/pytorch/pytorch/issues/20248)"
+                )
 
         world_size, rank = _get_distributed_world_rank()
         n_workers, worker_id = _get_worker_world_rank()
@@ -426,7 +424,7 @@ class ExperimentAxisQueryIterable(Iterable[XObsDatum]):
 
     def __getitem__(self, index: int) -> XObsDatum:
         raise NotImplementedError(
-            "``ExperimentAxisQueryIterable can only be iterated - does not support mapping"
+            "`ExperimentAxisQueryIterable` can only be iterated - does not support mapping"
         )
 
     def _io_batch_iter(


### PR DESCRIPTION
- `PipeClass` should be `Type[ExperimentAxisQueryIterDataPipe] | Type[ExperimentAxisQueryIterableDataset] | Type[ExperimentAxisQueryIterableDataset]`, not `ExperimentAxisQueryIterDataPipe | ExperimentAxisQueryIterableDataset | ExperimentAxisQueryIterableDataset`. IntelliJ flagged this, not sure why mypy didn't.
- Remove `root = "../../.."` from pyproject.toml (copied [from census](https://github.com/chanzuckerberg/cellxgene-census/blob/v1.15.0/api/python/cellxgene_census/pyproject.toml#L75-L77), I think)
