### PR TITLE
Support `somacore>=1.0.24` / `tiledbsoma>=1.15`

### DIFF
--- a/.github/workflows/python-tilledbsoma-ml-compat.yml
+++ b/.github/workflows/python-tilledbsoma-ml-compat.yml
@@ -31,6 +31,7 @@ jobs:
           - "tiledbsoma~=1.12.0"
           - "tiledbsoma~=1.13.0"
           - "tiledbsoma~=1.14.0"
+          - "tiledbsoma~=1.15.0rc4"
 
     runs-on: ${{ matrix.os }}
 

--- a/src/tiledbsoma_ml/pytorch.py
+++ b/src/tiledbsoma_ml/pytorch.py
@@ -27,7 +27,6 @@ import pyarrow as pa
 import scipy.sparse as sparse
 import tiledbsoma as soma
 import torch
-from somacore.query._eager_iter import EagerIterator as _EagerIterator
 
 from tiledbsoma_ml._csr import CSR_IO_Buffer
 from tiledbsoma_ml._distributed import (
@@ -36,6 +35,13 @@ from tiledbsoma_ml._distributed import (
 )
 from tiledbsoma_ml._experiment_locator import ExperimentLocator
 from tiledbsoma_ml._utils import NDArrayNumber, batched, splits
+
+try:
+    # somacore<1.0.24 / tiledbsoma<1.15
+    from somacore.query._eager_iter import EagerIterator as _EagerIterator
+except ImportError:
+    # somacore>=1.0.24 / tiledbsoma>=1.15
+    from tiledbsoma._eager_iter import EagerIterator as _EagerIterator
 
 logger = logging.getLogger("tiledbsoma_ml.pytorch")
 

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -71,6 +71,7 @@ def add_dataframe(coll: CollectionBase, key: str, value_range: range) -> None:
             ]
         ),
         index_column_names=["soma_joinid"],
+        domain=((value_range.start, value_range.stop),),
     )
     df.write(
         pa.Table.from_pydict(


### PR DESCRIPTION
- `somacore==1.0.24` moved some classes into `tiledbsoma` (e.g. `EagerIterator`)
- `tiledbsoma` 1.15 requires the `domain` arg to `DataFrame.create`