### PR TITLE
Adding `release.yml` for CI release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
       id-token: write
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build package
         run: pip install build && python -m build && ls -l dist
       - name: Publish package distributions to Test PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+on:
+  release:
+    types: [ 'published' ]
+
+jobs:
+  pypi-publish:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Setup Python
+      - uses: actions/setup-python@v2
+      - name: Checkout
+      - uses: actions/checkout@v2
+      - name: Build package
+      - run: pip install build && python -m build && ls -l dist
+      - name: Publish package distributions to PyPI
+        if: "!github.event.release.prerelease"
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,16 @@ jobs:
       id-token: write
     steps:
       - name: Setup Python
-      - uses: actions/setup-python@v2
+        uses: actions/setup-python@v2
       - name: Checkout
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
       - name: Build package
-      - run: pip install build && python -m build && ls -l dist
+        run: pip install build && python -m build && ls -l dist
+      - name: Publish package distributions to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        continue-on-error: true
+        with:
+          repository_url: https://test.pypi.org/legacy/
       - name: Publish package distributions to PyPI
         if: "!github.event.release.prerelease"
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build package


### PR DESCRIPTION
This PR:

- Introduces a `release.yml` for releasing the project on PyPI registry, using a trusted publisher.