### PR TITLE
Make version dynamic

### DIFF
--- a/.github/workflows/python-tiledbsoma-ml.yml
+++ b/.github/workflows/python-tiledbsoma-ml.yml
@@ -66,6 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # for setuptools-scm
 
       - uses: actions/setup-python@v5
         with:
@@ -75,3 +77,13 @@ jobs:
         run: |
           pip install --upgrade build pip wheel setuptools setuptools-scm
           python -m build .
+
+      - name: Install (and test version string)
+        run: |
+          git tag -l
+          git describe --dirty --tags --long --match *[0-9]*
+          python -m setuptools_scm
+          pip install --prefer-binary dist/tiledbsoma_ml-*.whl
+          pip list | grep tiledbsoma-ml
+          # Change directory to avoid importing local source package
+          cd .. && python -c "import tiledbsoma_ml as soma_ml; print(soma_ml.__version__)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -50,8 +50,7 @@ Repository = "https://github.com/TileDB-Inc/TileDB-SOMA-ML.git"
 Issues = "https://github.com/TileDB-Inc/TileDB-SOMA-ML/issues"
 Changelog = "https://github.com/TileDB-Inc/TileDB-SOMA-ML/blob/main/CHANGELOG.md"
 
-[tool.setuptools.dynamic]
-version = {attr = "tiledbsoma_ml.__version__"}
+[tool.setuptools_scm]
 
 [tool.setuptools.package-data]
 "tiledbsoma_ml" = ["py.typed"]

--- a/src/tiledbsoma_ml/__init__.py
+++ b/src/tiledbsoma_ml/__init__.py
@@ -5,11 +5,18 @@
 
 """An API to support machine learning applications built on SOMA."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 from .dataloader import experiment_dataloader
 from .datapipe import ExperimentAxisQueryIterDataPipe
 from .dataset import ExperimentAxisQueryIterableDataset
 
-__version__ = "0.1.0-dev"
+try:
+    __version__ = version("tiledbsoma-ml")
+except PackageNotFoundError:
+    # package is not installed
+    pass
+
 
 __all__ = [
     "ExperimentAxisQueryIterDataPipe",


### PR DESCRIPTION
## Motivation

The version is currently hard-coded as 0.1.0-dev:

https://github.com/single-cell-data/TileDB-SOMA-ML/blob/e985fcb9c946fd118c9f9852da54dc9ac7c7dc0f/src/tiledbsoma_ml/__init__.py#L12

Thus even though there are tags available, they are ignored:


```sh
git clone https://github.com/single-cell-data/TileDB-SOMA-ML.git
cd TileDB-SOMA-ML/
git log -n 1 --oneline
## e985fcb (HEAD -> main, origin/main, origin/HEAD) compat GHA: use tdbs 1.15.2 (#24)
git tag -l
## 0.1.0alpha
## 0.1.0alpha2
git describe --dirty --tags --long --match *[0-9]*
## 0.1.0alpha2-1-ge985fcb

python -m venv ./venv-ml
source ./venv-ml/bin/activate
pip install build setuptools-scm

python -m setuptools_scm
## Warning: could not use pyproject.toml, using default configuration.
##  Reason: /tmp/TileDB-SOMA-ML/pyproject.toml does not contain a tool.setuptools_scm section.
## 0.1.0a3.dev1+ge985fcb
python -m build .
## Successfully built tiledbsoma_ml-0.1.0.dev0.tar.gz and tiledbsoma_ml-0.1.0.dev0-py3-none-any.whl
pip install --prefer-binary dist/tiledbsoma_ml-*.tar.gz

pip list | grep tiledbsoma-ml
## tiledbsoma-ml            0.1.0.dev0
# Switch directory to not import source package
cd .. && python -c "import tiledbsoma_ml as soma_ml; print(soma_ml.__version__)"
## 0.1.0-dev
```

And because of this hard-coding, I can't override the version string in the conda recipe using `SETUPTOOLS_SCM_PRETEND_VERSION` (https://github.com/TileDB-Inc/tiledb-soma-ml-feedstock/issues/5#issuecomment-2539517380).

## Solution

I decided to use the [latest setuptools-scm 8+ solution](https://setuptools-scm.readthedocs.io/en/latest/), so I deleted the section `tool.setuptools.dynamic`, which uses the [dynamic metadata feature of setuptools](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata).

I managed to get it working. I also confirmed that `SETUPTOOLS_SCM_PRETEND_VERSION` mostly works now.

There is still some strangeness. First, our `alpha` gets truncated to `a`. I think this is because of [PEP 440](https://peps.python.org/pep-0440/#pre-releases). Also, it reports `0.1.0a3` (as above in the output from `python -m setuptools_scm`), which I don't understand. Hopefully once we drop the `alpha` from our version strings the dynamic versions will be more predictable.