### PR TITLE
Restore `encoders.py`, expose mini-batches as `dataclass`es or `torch.Tensor`s

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ intersphinx_mapping = {
     "tiledbsoma": ("https://tiledbsoma.readthedocs.io/en/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "sklearn": ("https://scikit-learn.org/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
 
@@ -55,6 +56,7 @@ rst_prolog = """
 .. |Iterable| replace:: :class:`~typing.Iterable`
 .. |Iterator| replace:: :class:`~typing.Iterator`
 .. |ExperimentDataset| replace:: :class:`~tiledbsoma_ml.dataset.ExperimentDataset`
+.. |Encoder| replace:: :class:`~tiledbsoma_ml.encoders.Encoder`
 .. |__iter__| replace:: :obj:`__iter__ <.__iter__>`
 .. |XLocator| replace:: :class:`~tiledbsoma_ml.x_locator.XLocator`
 .. |ExperimentDataset.__iter__| replace:: :obj:`ExperimentDataset.__iter__ <tiledbsoma_ml.ExperimentDataset.__iter__>`
@@ -88,6 +90,7 @@ rst_prolog = """
 .. |Measurement| replace:: :class:`~tiledbsoma.Measurement`
 .. |SparseNDArray| replace:: :class:`~tiledbsoma.SparseNDArray`
 .. |torch.distributed| replace:: :mod:`torch.distributed`
+.. |torch.Tensor| replace:: :class:`~torch.Tensor`
 .. |DataLoader| replace:: :class:`~torch.utils.data.DataLoader`
 .. |IterableDataset| replace:: :class:`~torch.utils.data.IterableDataset`
 .. |DistributedDataParallel| replace:: :class:`~torch.nn.parallel.DistributedDataParallel`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,14 @@ Batching and Data Management
    :members:
    :undoc-members:
 
+``encoders``
+^^^^^^^^^^^^
+
+.. automodule:: tiledbsoma_ml.encoders
+   :members:
+   :undoc-members:
+   :member-order: bysource
+
 ``_query_ids``
 ^^^^^^^^^^^^^^
 

--- a/src/tiledbsoma_ml/_common.py
+++ b/src/tiledbsoma_ml/_common.py
@@ -2,23 +2,90 @@
 #
 # Licensed under the MIT License.
 """Type aliases used in |ExperimentDataset| and |experiment_dataloader|."""
+from __future__ import annotations
 
 from typing import Any, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+import torch
+from attrs import Factory, define
 from scipy import sparse
+from scipy.sparse import csr_matrix
+from torch import Tensor
+
+from tiledbsoma_ml.encoders import Encoder
 
 NDArrayNumber = npt.NDArray[np.number[Any]]
 NDArrayJoinId = npt.NDArray[np.int64]
 """|ndarray| of ``int64``s representing SOMA joinids."""
 XBatch = Union[NDArrayNumber, sparse.csr_matrix]
-MiniBatch = Tuple[XBatch, pd.DataFrame]
-"""Yielded by |ExperimentDataset|; pairs a slice of ``X`` rows with corresponding ``obs`` rows.
+XObsTensors = Tuple[Tensor, Tensor]
+"""|torch.Tensor|s corresponding to ``X`` and (encoded) ``obs``, (resp.)."""
 
-When |return_sparse_X| is ``False`` (the default), a |MiniBatch| is a tuple of |ndarray| and |pd.DataFrame| (for ``X``
-and ``obs``, respectively). If ``batch_size=1``, the |ndarray| will have rank 1 (representing a single row), otherwise
-it will have rank 2. If |return_sparse_X| is ``True``, the ``X`` slice is returned as a |csr_matrix| (which is always
-rank 2).
-"""
+
+@define(init=False)
+class MiniBatch:
+    """Yielded by |ExperimentDataset|; pairs a slice of ``X`` rows with corresponding ``obs`` rows.
+
+    When |return_sparse_X| is ``False`` (the default), a |MiniBatch| is a tuple of |ndarray| and |pd.DataFrame| (for
+    ``X`` and ``obs``, respectively). If ``batch_size=1``, the |ndarray| will have rank 1 (representing a single row),
+    otherwise it will have rank 2. If |return_sparse_X| is ``True``, the ``X`` slice is returned as a |csr_matrix|
+    (which is always rank 2).
+    """
+
+    X: XBatch
+    obs: pd.DataFrame
+    encoders: list[Encoder] = Factory(list)
+
+    def __init__(
+        self,
+        X: XBatch,
+        obs: pd.DataFrame,
+        batch_size: int | None = None,
+        encoders: list[Encoder] | None = None,
+    ):
+        if batch_size == 1 and not isinstance(X, csr_matrix):
+            # "Squeeze" batches of size 1
+            X = X[0]
+
+        self.__attrs_init__(
+            X=X,
+            obs=obs,
+            encoders=encoders or [],
+        )
+
+    @property
+    def obs_encoded(self) -> Tensor:
+        obs = self.obs
+        obs_encoded = pd.DataFrame()
+
+        # Add the soma_joinid to the original obs, in case that is requested by the encoders.
+        obs["soma_joinid"] = obs.index
+
+        for enc in self.encoders:
+            obs_encoded[enc.name] = enc.transform(obs)
+
+        # `to_numpy()` avoids copying the numpy array data
+        return torch.from_numpy(obs_encoded.to_numpy())
+
+    @property
+    def tensors(self) -> XObsTensors:
+        X = self.X
+        if isinstance(X, csr_matrix):
+            coo = X.tocoo()
+            X = torch.sparse_coo_tensor(
+                # Note: The `np.array` seems unnecessary, but PyTorch warns bare array is "extremely slow"
+                indices=torch.from_numpy(np.array([coo.row, coo.col])),
+                values=coo.data,
+                size=coo.shape,
+            )
+        else:
+            X = torch.from_numpy(X)
+
+        return X, self.obs_encoded
+
+    @property
+    def tpl(self) -> tuple[XBatch, pd.DataFrame]:
+        return self.X, self.obs

--- a/src/tiledbsoma_ml/encoders.py
+++ b/src/tiledbsoma_ml/encoders.py
@@ -1,0 +1,132 @@
+import abc
+import functools
+from typing import Any, List
+
+import numpy.typing as npt
+import pandas as pd
+from sklearn.preprocessing import LabelEncoder as SklearnLabelEncoder
+
+
+class Encoder(abc.ABC):
+    """Base class for ``obs`` encoders.
+
+    To define a custom encoder, five methods must be implemented:
+
+    - ``fit``: defines how the encoder will be fitted to the data.
+    - ``transform``: defines how the encoder will be applied to the data
+      in order to create an ``obs`` tensor.
+    - ``inverse_transform``: defines how to decode the encoded values back
+      to the original values.
+    - ``name``: The name of the encoder. This will be used as the key in the
+      dictionary of encoders. Each encoder passed to a |ExperimentDataset| must have a unique name.
+    - ``columns``: List of columns in ``obs`` that the encoder will be applied to.
+
+    See the implementation of :class:`LabelEncoder` for an example.
+    """
+
+    @abc.abstractmethod
+    def fit(self, obs: pd.DataFrame) -> None:
+        """Fit the encoder with obs."""
+        pass
+
+    @abc.abstractmethod
+    def transform(self, df: pd.DataFrame) -> npt.NDArray[Any]:
+        """Transform the obs :class:`pandas.DataFrame` into a :class:`pandas.DataFrame` of encoded values."""
+        pass
+
+    @abc.abstractmethod
+    def inverse_transform(self, encoded_values: npt.NDArray[Any]) -> npt.NDArray[Any]:
+        """Inverse transform the encoded values back to the original values."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Name of the encoder."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def columns(self) -> List[str]:
+        """Columns in ``obs`` that the encoder will be applied to."""
+        pass
+
+
+class LabelEncoder(Encoder):
+    """Default encoder based on :class:`sklearn.preprocessing.LabelEncoder`."""
+
+    def __init__(self, col: str) -> None:
+        self._encoder = SklearnLabelEncoder()
+        self.col = col
+
+    def fit(self, obs: pd.DataFrame) -> None:
+        """Fit the encoder with ``obs``."""
+        self._encoder.fit(obs[self.col].unique())
+
+    def transform(self, df: pd.DataFrame) -> npt.NDArray[Any]:
+        """Transform the obs :class:`pandas.DataFrame` into a :class:`pandas.DataFrame` of encoded values."""
+        return self._encoder.transform(df[self.col])  # type: ignore
+
+    def inverse_transform(self, encoded_values: npt.NDArray[Any]) -> npt.NDArray[Any]:
+        """Inverse transform the encoded values back to the original values."""
+        return self._encoder.inverse_transform(encoded_values)  # type: ignore
+
+    @property
+    def name(self) -> str:
+        """Name of the encoder."""
+        return self.col
+
+    @property
+    def columns(self) -> List[str]:
+        """Columns in ``obs`` that the encoder will be applied to."""
+        return [self.col]
+
+    @property
+    def classes_(self):  # type: ignore
+        """Classes of the encoder."""
+        return self._encoder.classes_
+
+
+class BatchEncoder(Encoder):
+    """An encoder that concatenates and encodes several ``obs`` columns."""
+
+    def __init__(self, cols: List[str], name: str = "batch"):
+        self.cols = cols
+        from sklearn.preprocessing import LabelEncoder
+
+        self._name = name
+        self._encoder = LabelEncoder()
+
+    def _join_cols(self, df: pd.DataFrame):  # type: ignore
+        return functools.reduce(
+            lambda a, b: a + b, [df[c].astype(str) for c in self.cols]
+        )
+
+    def transform(self, df: pd.DataFrame) -> npt.NDArray[Any]:
+        """Transform the obs :class:`pandas.DataFrame` into a :class:`pandas.DataFrame` of encoded values."""
+        arr = self._join_cols(df)
+        return self._encoder.transform(arr)  # type: ignore
+
+    def inverse_transform(self, encoded_values: npt.NDArray[Any]) -> npt.NDArray[Any]:
+        """Inverse transform the encoded values back to the original values."""
+        return self._encoder.inverse_transform(encoded_values)  # type: ignore
+
+    def fit(self, obs: pd.DataFrame) -> None:
+        """Fit the encoder with ``obs``."""
+        arr = self._join_cols(obs)
+        self._encoder.fit(arr.unique())
+
+    @property
+    def columns(self) -> List[str]:
+        """Columns in ``obs`` that the encoder will be applied to."""
+        return self.cols
+
+    @property
+    def name(self) -> str:
+        """Name of the encoder."""
+        return self._name
+
+    @property
+    def classes_(self):  # type: ignore
+        """Classes of the encoder."""
+        return self._encoder.classes_

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -229,7 +229,9 @@ def assert_batches_equal(
 ):
     try:
         assert len(batches) == len(expected_batches)
-        for (a_X, a_obs), (e_X, e_obs) in zip(batches, expected_batches):
+        for (a_X, a_obs), (e_X, e_obs) in zip(
+            map(lambda b: b.tpl, batches), expected_batches
+        ):
             if return_sparse_X:
                 assert isinstance(a_X, csr_matrix)
                 a_X = a_X.toarray()
@@ -254,6 +256,7 @@ def batch_idxs_str(batches: List[MiniBatch]) -> str:
                     obs.soma_joinid.astype(str) if "soma_joinid" in obs else obs.label
                 ).tolist()
             )
-            for _, obs in batches
+            for batch in batches
+            for _, obs in [batch.tpl]
         ]
     )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -23,7 +23,7 @@ from tiledbsoma_ml._common import MiniBatch
 @fixture
 def batch_iter(ds: ExperimentDataset) -> Iterator[MiniBatch]:
     """Iterator over an |ExperimentDataset|'s |MiniBatch|'s."""
-    return iter(ds)
+    return ds.mini_batches()
 
 
 @fixture
@@ -95,7 +95,11 @@ def test_obs3_shuf3_io3_batch3(check):
 )
 @sweep(use_eager_fetch=[True, False])
 def test_large_obs_ids(batches: List[MiniBatch], check):
-    soma_joinids = np.concatenate([obs["soma_joinid"].to_numpy() for X, obs in batches])
+    soma_joinids = np.concatenate([
+        obs["soma_joinid"].to_numpy()
+        for batch in batches
+        for _, obs in [batch.tpl]
+    ])
     assert_array_equal(soma_joinids, np.arange(100_000_000, 100_000_003))
 
 


### PR DESCRIPTION
TODO:
- Update notebooks
- Audit docstrs
- Add tests that verify `tuple[Tensor, Tensor]`s (current tests check `tuple[XBatch, pd.DataFrame]`s.