### PR TITLE
Prepare `release.yml` for prod PyPI publish

### DIFF
--- a/.github/workflows/python-tiledbsoma-ml.yml
+++ b/.github/workflows/python-tiledbsoma-ml.yml
@@ -9,6 +9,8 @@ on:
       - "scripts/**"
       - "notebooks/**"
       - "www/**"
+      - ".github/**"
+      - "!.github/workflows/python-tiledbsoma-ml.yml"
   push:
     branches: [main]
     paths-ignore:
@@ -17,6 +19,8 @@ on:
       - "scripts/**"
       - "notebooks/**"
       - "www/**"
+      - ".github/**"
+      - "!.github/workflows/python-tiledbsoma-ml.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python-tilledbsoma-ml-compat.yml
+++ b/.github/workflows/python-tilledbsoma-ml-compat.yml
@@ -9,6 +9,8 @@ on:
       - "scripts/**"
       - "notebooks/**"
       - "www/**"
+      - ".github/**"
+      - "!.github/workflows/python-tiledbsoma-ml.yml"
   push:
     branches: [main]
     paths-ignore:
@@ -17,6 +19,8 @@ on:
       - "scripts/**"
       - "notebooks/**"
       - "www/**"
+      - ".github/**"
+      - "!.github/workflows/python-tiledbsoma-ml.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,35 +1,63 @@
-name: Release
+# New release tags trigger this workflow to publish to test.pypi.org.
+# If that looks good, a `workflow_dispatch` can be used to publish to pypi.org (with `prod-pypi` set to 'true').
+name: Publish to PyPI
 on:
+  push:
+    tags:
+      - 'v[0-9]+*'
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'The tag version to release (e.g., v1.0.0)'
-        required: true
-        default: 'v0.1.0alpha'
-      environment:
-        description: 'PyPI environment to release to (test or production)'
-        required: true
-        default: 'test'
-
+      prod-pypi:
+        type: boolean
+        description: 'Publish to pypi.org (default: test.pypi.org)'
+      ref:
+        description: 'Git ref to checkout, build, and publish'
+      verbose:
+        type: boolean
+        description: 'Enable debug output from pypa/gh-action-pypi-publish'
 jobs:
-  pypi-publish:
-    name: upload release to PyPI
+  build:
+    name: Build package
     runs-on: ubuntu-latest
-    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || '' }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.11'
+      - name: Build package
+        run: |
+          pip install build
+          python -m build
+          ls -l dist
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+          retention-days: 1
+  publish:
+    name: Upload release to ${{ inputs.prod-pypi != true && 'test ' || '' }}PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://${{ inputs.prod-pypi != true && 'test.' || '' }}pypi.org/p/tiledbsoma_ml  # Displayed in GHA UI
     permissions:
       id-token: write
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v5
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build package
-        run: pip install build && python -m build && ls -l dist
-      - name: Publish package distributions to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        continue-on-error: true
+      - name: Print inputs
+        run: |
+          echo "Inputs: ${{ toJSON(github.event.inputs) }}"
+      - name: Download distributions
+        uses: actions/download-artifact@v4
         with:
-          repository_url: https://test.pypi.org/legacy/
-      - name: Publish package distributions to PyPI
-        if: "!github.event.release.prerelease"
+          name: python-package-distributions
+          path: dist/
+      - name: Publish package distributions to ${{ inputs.prod-pypi != true && 'test ' || '' }}PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{ inputs.prod-pypi != true && 'https://test.pypi.org/legacy/' || '' }}
+          verbose: ${{ inputs.verbose }}


### PR DESCRIPTION
Changes `release.yml` so that:
- A new release tag publishes to test.pypi.org.
- If that looks good, a `workflow_dispatch` can be used to publish to pypi.org (with `prod-pypi` input set).

I also created a `pypi` environment ([/settings/environments](https://github.com/single-cell-data/TileDB-SOMA-ML/settings/environments)).

~I'm not sure how to test this, other than merging, creating a GH release, verifying test PyPI publish, and then triggering prod PyPI publish…~

Update: runbook for first PyPI release was:

1. Create GH tag (`v0.1.0a3`) and release
2. Test this PR by manually triggering it to publish to test PyPI (from newly-created tag `v0.1.0a3`)
3. If that looks good, further verify this PR by manually triggering prod PyPI release.
4. If that looks good, merge this PR

Results:
- Step 2 [failed](https://github.com/single-cell-data/TileDB-SOMA-ML/actions/runs/13729053722/job/38402404659) on first attempt:
  - `tiledbsoma-ml` project was created [on test PyPI](https://test.pypi.org/project/tiledbsoma-ml/), but the release itself failed.
  - A second run (with verbose logging, but no substantive changes) then [succeeded](https://github.com/single-cell-data/TileDB-SOMA-ML/actions/runs/13729515792/job/38403520532) 🤷.
- Step 3 failed a few times, due to GHA ternary operator footguns:
  - I originally had expressions like `${{ inputs.prod-pypi && '' || 'test.' }}` (for distinguishing "test" vs. "prod" PyPI)
  - Turns out, if either value is false-y (`''` in this case), that needs to be in the `||` branch. As written, `inputs.prod-pypi && ''` is trivially false-y, and the expression always evaluates+returns the `|| 'test.'` branch.
  - After fixing that, I had `${{ inputs.prod-pypi != 'true' && 'test.' || '' }}`, but `'true'` is wrong, it has to be `true`.
  - The correct expression is: `${{ inputs.prod-pypi != true && 'test.' || '' }}`.

After resolving those issues, [a manual dispatch](https://github.com/single-cell-data/TileDB-SOMA-ML/actions/runs/13730193954/job/38405582871) of `release.yml` on this branch successfully published [`tiledbsoma_ml==0.1.0a3`](https://pypi.org/project/tiledbsoma-ml/0.1.0a3/) to PyPI 🎉:

```bash
gh workflow run release.yml -b rw/pypi -r ref=v0.1.0a3 -r prod-pypi=true
```

Going forward, the release process should look like:

1. Create GH tag and release
2. That will trigger test PyPI publish
3. If that looks good, manually dispatch `release.yml` to perform prod-PyPI publish