### PR TITLE
Updated Default Dataloader Args

### DIFF
--- a/notebooks/pytorch_scvi.ipynb
+++ b/notebooks/pytorch_scvi.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-05-08T20:16:35.993242Z",
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-05-08T20:16:36.878889Z",
@@ -98,7 +98,7 @@
        "    'census_spatial_sequencing': 's3://cellxgene-census-public-us-west-2/cell-census/2025-01-30/soma/census_spatial_sequencing' (unopened)>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-05-08T20:16:37.034472Z",
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-05-08T20:17:17.395310Z",
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-05-08T20:17:17.463797Z",
@@ -221,9 +221,9 @@
        "      <td>4.413931</td>\n",
        "      <td>3704.056931</td>\n",
        "      <td>3</td>\n",
-       "      <td>3951.0</td>\n",
+       "      <td>2431.0</td>\n",
        "      <td>0.832676</td>\n",
-       "      <td>False</td>\n",
+       "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -248,7 +248,7 @@
        "      <td>0.010616</td>\n",
        "      <td>0.011960</td>\n",
        "      <td>4</td>\n",
-       "      <td>5631.5</td>\n",
+       "      <td>4858.0</td>\n",
        "      <td>0.732153</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
@@ -257,7 +257,7 @@
        "      <td>0.845290</td>\n",
        "      <td>370.855284</td>\n",
        "      <td>2</td>\n",
-       "      <td>7351.0</td>\n",
+       "      <td>7289.0</td>\n",
        "      <td>0.796814</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
@@ -337,11 +337,11 @@
        "\n",
        "             highly_variable_rank  variances_norm  highly_variable  \n",
        "soma_joinid                                                         \n",
-       "0                          3951.0        0.832676            False  \n",
+       "0                          2431.0        0.832676             True  \n",
        "1                          2662.0        1.116213             True  \n",
        "2                          5417.0        0.223651            False  \n",
-       "3                          5631.5        0.732153            False  \n",
-       "4                          7351.0        0.796814            False  \n",
+       "3                          4858.0        0.732153            False  \n",
+       "4                          7289.0        0.796814            False  \n",
        "...                           ...             ...              ...  \n",
        "52478                      7940.0        0.000000            False  \n",
        "52479                      7941.0        0.000000            False  \n",
@@ -352,7 +352,7 @@
        "[52483 rows x 6 columns]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -375,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-05-08T20:17:20.660384Z",
@@ -389,7 +389,7 @@
        "(137250, 8000, 47)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -435,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-05-08T20:17:20.723652Z",
@@ -459,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-05-08T20:18:32.765874Z",
@@ -478,24 +478,24 @@
      ]
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "999815bb8881488597311b7e0174109b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Training:   0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/1: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [01:16<00:00, 76.10s/it, v_num=1, train_loss_step=2.81e+3, train_loss_epoch=4.21e+3]"
+     ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
       "`Trainer.fit` stopped: `max_epochs=1` reached.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/1: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [01:16<00:00, 76.11s/it, v_num=1, train_loss_step=2.81e+3, train_loss_epoch=4.21e+3]\n"
      ]
     }
    ],
@@ -518,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-05-08T20:18:32.908358Z",
@@ -564,7 +564,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-05-08T20:18:33.002517Z",
@@ -881,7 +881,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -13,6 +13,7 @@ from torch.utils.data import DataLoader
 from tiledbsoma_ml import ExperimentDataset, experiment_dataloader
 from tiledbsoma_ml._common import MiniBatch
 
+
 DEFAULT_DATALOADER_KWARGS: dict[str, Any] = {
     "pin_memory": torch.cuda.is_available(),
     "persistent_workers": True,

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -17,7 +17,7 @@ from tiledbsoma_ml._common import MiniBatch
 DEFAULT_DATALOADER_KWARGS: dict[str, Any] = {
     "pin_memory": torch.cuda.is_available(),
     "persistent_workers": True,
-    "num_workers": max(os.cpu_count() // 2, 1),
+    "num_workers": max(((os.cpu_count() or 1) // 2), 1)
 }
 
 class SCVIDataModule(LightningDataModule):  # type: ignore[misc]

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -12,6 +12,11 @@ from torch.utils.data import DataLoader
 from tiledbsoma_ml import ExperimentDataset, experiment_dataloader
 from tiledbsoma_ml._common import MiniBatch
 
+DEFAULT_DATALOADER_KWARGS: dict[str, Any] = {
+    "pin_memory": torch.cuda.is_available(),
+    "persistent_workers": True,
+    "num_workers": max(os.cpu_count() // 2, 1),
+}
 
 class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
     """PyTorch Lightning DataModule for training scVI models from SOMA data.
@@ -61,9 +66,10 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
         self.query = query
         self.dataset_args = args
         self.dataset_kwargs = kwargs
-        self.dataloader_kwargs = (
-            dataloader_kwargs if dataloader_kwargs is not None else {}
-        )
+        self.dataloader_kwargs = {
+            **DEFAULT_DATALOADER_KWARGS,
+            **(dataloader_kwargs or {}),
+        }
         self.batch_column_names = (
             batch_column_names
             if batch_column_names is not None

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import os
 from typing import Any, Sequence
 
 import pandas as pd
 import torch
-import os
 from lightning import LightningDataModule
 from sklearn.preprocessing import LabelEncoder
 from tiledbsoma import ExperimentAxisQuery
@@ -16,8 +16,9 @@ from tiledbsoma_ml._common import MiniBatch
 DEFAULT_DATALOADER_KWARGS: dict[str, Any] = {
     "pin_memory": torch.cuda.is_available(),
     "persistent_workers": True,
-    "num_workers": max(((os.cpu_count() or 1) // 2), 1)
+    "num_workers": max(((os.cpu_count() or 1) // 2), 1),
 }
+
 
 class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
     """PyTorch Lightning DataModule for training scVI models from SOMA data.

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -13,7 +13,6 @@ from torch.utils.data import DataLoader
 from tiledbsoma_ml import ExperimentDataset, experiment_dataloader
 from tiledbsoma_ml._common import MiniBatch
 
-
 DEFAULT_DATALOADER_KWARGS: dict[str, Any] = {
     "pin_memory": torch.cuda.is_available(),
     "persistent_workers": True,

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -4,6 +4,7 @@ from typing import Any, Sequence
 
 import pandas as pd
 import torch
+import os
 from lightning import LightningDataModule
 from sklearn.preprocessing import LabelEncoder
 from tiledbsoma import ExperimentAxisQuery


### PR DESCRIPTION
Motivation behind this is to have better out of the box performance for training. In my testing for both in-memory and S3 datasets (tested w a portion of cellxgene), persisting workers leads to around 40-50% improvement in runtime/samples handled per second. Also helps push the GPU usage by a ton. `Pin_memory` has a lesser impact but regardless seems like a good default to have since copying from CPU to GPU is something we do pretty regularly in our training pipeline.