### PR TITLE
Validation dataloader so that `train_size` gets used

### DIFF
--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -12,6 +12,7 @@ from torch.utils.data import DataLoader
 
 from tiledbsoma_ml import ExperimentDataset, experiment_dataloader
 from tiledbsoma_ml._common import MiniBatch
+from tiledbsoma_ml._query_ids import QueryIDs
 
 DEFAULT_DATALOADER_KWARGS: dict[str, Any] = {
     "pin_memory": torch.cuda.is_available(),
@@ -38,6 +39,7 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
         batch_column_names: Sequence[str] | None = None,
         batch_labels: Sequence[str] | None = None,
         dataloader_kwargs: dict[str, Any] | None = None,
+        train_size: float = 1.0,
         **kwargs: Any,
     ):
         """Args:
@@ -63,6 +65,10 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
 
         dataloader_kwargs: dict, optional
         Keyword arguments passed to `tiledbsoma_ml.experiment_dataloader()`, e.g. `num_workers`.
+        
+        train_size: float, optional
+        Fraction of data to use for training (between 0 and 1). Default is 1.0 (use all data for training).
+        If less than 1.0, the remaining data will be used for validation.
         """
         super().__init__()
         self.query = query
@@ -93,21 +99,59 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
             batch_labels = obs_df[self.batch_colname].unique()
         self.batch_labels = batch_labels
         self.batch_encoder = LabelEncoder().fit(self.batch_labels)
+        self.train_size = train_size
+        self.train_query_ids = None
+        self.val_query_ids = None
 
     def setup(self, stage: str | None = None) -> None:
-        # Instantiate the ExperimentDataset with the provided args and kwargs.
-        self.train_dataset = ExperimentDataset(
+        # Create QueryIDs from the query
+        query_ids = QueryIDs.create(self.query)
+        
+        # Split data into train and validation sets if train_size < 1.0
+        if self.train_size < 1.0:
+            # Use QueryIDs.split() for efficient splitting
+            val_size = 1.0 - self.train_size
+            self.train_query_ids, self.val_query_ids = query_ids.split(
+                self.train_size, val_size, seed=42
+            )
+        else:
+            # Use all data for training
+            self.train_query_ids = query_ids
+            self.val_query_ids = None
+
+    def train_dataloader(self) -> DataLoader:
+        assert self.train_query_ids is not None, "setup() must be called before train_dataloader()"
+        
+        # Create dataset with train query_ids
+        train_dataset = ExperimentDataset(
             self.query,
             *self.dataset_args,
             obs_column_names=self.batch_column_names,  # type: ignore[arg-type]
+            query_ids=self.train_query_ids,
             **self.dataset_kwargs,  # type: ignore[misc]
         )
-
-    def train_dataloader(self) -> DataLoader:
         return experiment_dataloader(
-            self.train_dataset,
+            train_dataset,
             **self.dataloader_kwargs,
         )
+    
+    def val_dataloader(self) -> DataLoader | None:
+        if self.val_query_ids is not None:
+            # Create dataset with validation query_ids
+            val_dataset = ExperimentDataset(
+                self.query,
+                *self.dataset_args,
+                obs_column_names=self.batch_column_names,  # type: ignore[arg-type]
+                query_ids=self.val_query_ids,
+                **self.dataset_kwargs,  # type: ignore[misc]
+            )
+            return experiment_dataloader(
+                val_dataset,
+                **self.dataloader_kwargs,
+            )
+        else:
+            # No validation data if train_size == 1.0
+            return None
 
     def _add_batch_col(
         self, obs_df: pd.DataFrame, inplace: bool = False

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from typing import Any, Sequence
 
+import numpy as np
 import pandas as pd
 import torch
 from lightning import LightningDataModule
@@ -41,6 +42,7 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
         batch_labels: Sequence[str] | None = None,
         dataloader_kwargs: dict[str, Any] | None = None,
         train_size: float = 1.0,
+        seed: int = 42,
         **kwargs: Any,
     ):
         """Args:
@@ -70,6 +72,9 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
         train_size: float, optional
         Fraction of data to use for training (between 0 and 1). Default is 1.0 (use all data for training).
         If less than 1.0, the remaining data will be used for validation.
+        
+        seed: int, optional
+        Random seed for deterministic train/validation split. Default is 42.
         """
         super().__init__()
         self.query = query
@@ -101,6 +106,7 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
         self.batch_labels = batch_labels
         self.batch_encoder = LabelEncoder().fit(self.batch_labels)
         self.train_size = train_size
+        self.seed = seed
         self.train_query_ids = None
         self.val_query_ids = None
         self.x_locator = None
@@ -120,7 +126,7 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
             # Use QueryIDs.random_split() for efficient splitting
             val_size = 1.0 - self.train_size
             self.train_query_ids, self.val_query_ids = query_ids.random_split(
-                self.train_size, val_size, seed=42
+                self.train_size, val_size, seed=self.seed
             )
         else:
             # Use all data for training
@@ -150,6 +156,10 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
     
     def val_dataloader(self) -> DataLoader | None:
         if self.val_query_ids is not None and self.x_locator is not None:
+            # Print validation indices for manual verification
+            val_ids = self.val_query_ids.obs_joinids
+            print(f"📊 Validation indices (seed={self.seed}): first 10: {val_ids[:10]}, last 10: {val_ids[-10:]}")
+            
             # Filter out query and layer_name from dataset_kwargs since we're using x_locator and query_ids
             filtered_kwargs = {k: v for k, v in self.dataset_kwargs.items() 
                               if k not in ('query', 'layer_name')}

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -13,6 +13,7 @@ from torch.utils.data import DataLoader
 from tiledbsoma_ml import ExperimentDataset, experiment_dataloader
 from tiledbsoma_ml._common import MiniBatch
 from tiledbsoma_ml._query_ids import QueryIDs
+from tiledbsoma_ml.x_locator import XLocator
 
 DEFAULT_DATALOADER_KWARGS: dict[str, Any] = {
     "pin_memory": torch.cuda.is_available(),
@@ -102,10 +103,17 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
         self.train_size = train_size
         self.train_query_ids = None
         self.val_query_ids = None
+        self.x_locator = None
+        self.layer_name = kwargs.get('layer_name', 'raw')
 
     def setup(self, stage: str | None = None) -> None:
-        # Create QueryIDs from the query
+        # Create QueryIDs and XLocator from the query
         query_ids = QueryIDs.create(self.query)
+        self.x_locator = XLocator.create(
+            self.query.experiment,
+            measurement_name=self.query.measurement_name,
+            layer_name=self.layer_name,
+        )
         
         # Split data into train and validation sets if train_size < 1.0
         if self.train_size < 1.0:
@@ -121,13 +129,14 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
 
     def train_dataloader(self) -> DataLoader:
         assert self.train_query_ids is not None, "setup() must be called before train_dataloader()"
+        assert self.x_locator is not None, "setup() must be called before train_dataloader()"
         
-        # Create dataset with train query_ids
+        # Create dataset with train query_ids and x_locator
         train_dataset = ExperimentDataset(
-            self.query,
-            *self.dataset_args,
-            obs_column_names=self.batch_column_names,  # type: ignore[arg-type]
+            x_locator=self.x_locator,
             query_ids=self.train_query_ids,
+            obs_column_names=self.batch_column_names,  # type: ignore[arg-type]
+            *self.dataset_args,
             **self.dataset_kwargs,  # type: ignore[misc]
         )
         return experiment_dataloader(
@@ -136,13 +145,13 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
         )
     
     def val_dataloader(self) -> DataLoader | None:
-        if self.val_query_ids is not None:
-            # Create dataset with validation query_ids
+        if self.val_query_ids is not None and self.x_locator is not None:
+            # Create dataset with validation query_ids and x_locator
             val_dataset = ExperimentDataset(
-                self.query,
-                *self.dataset_args,
-                obs_column_names=self.batch_column_names,  # type: ignore[arg-type]
+                x_locator=self.x_locator,
                 query_ids=self.val_query_ids,
+                obs_column_names=self.batch_column_names,  # type: ignore[arg-type]
+                *self.dataset_args,
                 **self.dataset_kwargs,  # type: ignore[misc]
             )
             return experiment_dataloader(

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -117,9 +117,9 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
         
         # Split data into train and validation sets if train_size < 1.0
         if self.train_size < 1.0:
-            # Use QueryIDs.split() for efficient splitting
+            # Use QueryIDs.random_split() for efficient splitting
             val_size = 1.0 - self.train_size
-            self.train_query_ids, self.val_query_ids = query_ids.split(
+            self.train_query_ids, self.val_query_ids = query_ids.random_split(
                 self.train_size, val_size, seed=42
             )
         else:
@@ -167,7 +167,6 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
                 **self.dataloader_kwargs,
             )
         else:
-            # No validation data if train_size == 1.0
             return None
 
     def _add_batch_col(

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from enum import Enum
 from typing import Any, Sequence
 
 import pandas as pd
@@ -20,6 +21,13 @@ DEFAULT_DATALOADER_KWARGS: dict[str, Any] = {
     "persistent_workers": True,
     "num_workers": max(((os.cpu_count() or 1) // 2), 1),
 }
+
+
+class DatasetSplit(Enum):
+    """Enum for dataset splits."""
+
+    TRAIN = "train"
+    VAL = "val"
 
 
 class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
@@ -134,35 +142,23 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
             self.train_query_ids = query_ids
             self.val_query_ids = None
 
-    def train_dataloader(self) -> DataLoader:
-        assert (
-            self.train_query_ids is not None
-        ), "setup() must be called before train_dataloader()"
-        assert (
-            self.x_locator is not None
-        ), "setup() must be called before train_dataloader()"
+    def _create_dataloader(self, split: DatasetSplit) -> DataLoader | None:
+        """Create a dataloader for the specified dataset split.
 
-        # Filter out query and layer_name from dataset_kwargs since we're using x_locator and query_ids
-        filtered_kwargs = {
-            k: v
-            for k, v in self.dataset_kwargs.items()
-            if k not in ("query", "layer_name")
+        Args:
+            split: The dataset split (TRAIN or VAL)
+
+        Returns:
+            DataLoader for the specified split, or None if the split doesn't exist
+        """
+        # Get the appropriate query_ids based on split
+        query_ids_map = {
+            DatasetSplit.TRAIN: self.train_query_ids,
+            DatasetSplit.VAL: self.val_query_ids,
         }
 
-        # Create dataset with train query_ids and x_locator
-        train_dataset = ExperimentDataset(
-            x_locator=self.x_locator,
-            query_ids=self.train_query_ids,
-            obs_column_names=list(self.batch_column_names),
-            **filtered_kwargs,
-        )
-        return experiment_dataloader(
-            train_dataset,
-            **self.dataloader_kwargs,
-        )
-
-    def val_dataloader(self) -> DataLoader | None:
-        if self.val_query_ids is None or self.x_locator is None:
+        query_ids = query_ids_map.get(split)
+        if query_ids is None or self.x_locator is None:
             return None
 
         # Filter out query and layer_name from dataset_kwargs since we're using x_locator and query_ids
@@ -172,17 +168,38 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
             if k not in ("query", "layer_name")
         }
 
-        # Create dataset with validation query_ids and x_locator
-        val_dataset = ExperimentDataset(
+        # Create dataset with appropriate query_ids
+        dataset = ExperimentDataset(
             x_locator=self.x_locator,
-            query_ids=self.val_query_ids,
+            query_ids=query_ids,
             obs_column_names=list(self.batch_column_names),
             **filtered_kwargs,
         )
         return experiment_dataloader(
-            val_dataset,
+            dataset,
             **self.dataloader_kwargs,
         )
+
+    def train_dataloader(self) -> DataLoader:
+        """Create the training dataloader.
+
+        Returns:
+            DataLoader for training data
+
+        Raises:
+            AssertionError: If setup() hasn't been called
+        """
+        loader = self._create_dataloader(DatasetSplit.TRAIN)
+        assert loader is not None, "setup() must be called before train_dataloader()"
+        return loader
+
+    def val_dataloader(self) -> DataLoader | None:
+        """Create the validation dataloader.
+
+        Returns:
+            DataLoader for validation data, or None if no validation split exists
+        """
+        return self._create_dataloader(DatasetSplit.VAL)
 
     def _add_batch_col(
         self, obs_df: pd.DataFrame, inplace: bool = False

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -156,10 +156,6 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
     
     def val_dataloader(self) -> DataLoader | None:
         if self.val_query_ids is not None and self.x_locator is not None:
-            # Print validation indices for manual verification
-            val_ids = self.val_query_ids.obs_joinids
-            print(f"📊 Validation indices (seed={self.seed}): first 10: {val_ids[:10]}, last 10: {val_ids[-10:]}")
-            
             # Filter out query and layer_name from dataset_kwargs since we're using x_locator and query_ids
             filtered_kwargs = {k: v for k, v in self.dataset_kwargs.items() 
                               if k not in ('query', 'layer_name')}

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -131,13 +131,17 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
         assert self.train_query_ids is not None, "setup() must be called before train_dataloader()"
         assert self.x_locator is not None, "setup() must be called before train_dataloader()"
         
+        # Filter out query and layer_name from dataset_kwargs since we're using x_locator and query_ids
+        filtered_kwargs = {k: v for k, v in self.dataset_kwargs.items() 
+                          if k not in ('query', 'layer_name')}
+        
         # Create dataset with train query_ids and x_locator
         train_dataset = ExperimentDataset(
             x_locator=self.x_locator,
             query_ids=self.train_query_ids,
             obs_column_names=self.batch_column_names,  # type: ignore[arg-type]
             *self.dataset_args,
-            **self.dataset_kwargs,  # type: ignore[misc]
+            **filtered_kwargs,  # type: ignore[misc]
         )
         return experiment_dataloader(
             train_dataset,
@@ -146,13 +150,17 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
     
     def val_dataloader(self) -> DataLoader | None:
         if self.val_query_ids is not None and self.x_locator is not None:
+            # Filter out query and layer_name from dataset_kwargs since we're using x_locator and query_ids
+            filtered_kwargs = {k: v for k, v in self.dataset_kwargs.items() 
+                              if k not in ('query', 'layer_name')}
+            
             # Create dataset with validation query_ids and x_locator
             val_dataset = ExperimentDataset(
                 x_locator=self.x_locator,
                 query_ids=self.val_query_ids,
                 obs_column_names=self.batch_column_names,  # type: ignore[arg-type]
                 *self.dataset_args,
-                **self.dataset_kwargs,  # type: ignore[misc]
+                **filtered_kwargs,  # type: ignore[misc]
             )
             return experiment_dataloader(
                 val_dataset,

--- a/src/tiledbsoma_ml/scvi.py
+++ b/src/tiledbsoma_ml/scvi.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 from typing import Any, Sequence
 
-import numpy as np
 import pandas as pd
 import torch
 from lightning import LightningDataModule
@@ -68,11 +67,11 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
 
         dataloader_kwargs: dict, optional
         Keyword arguments passed to `tiledbsoma_ml.experiment_dataloader()`, e.g. `num_workers`.
-        
+
         train_size: float, optional
         Fraction of data to use for training (between 0 and 1). Default is 1.0 (use all data for training).
         If less than 1.0, the remaining data will be used for validation.
-        
+
         seed: int, optional
         Random seed for deterministic train/validation split. Default is 42.
         """
@@ -107,10 +106,10 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
         self.batch_encoder = LabelEncoder().fit(self.batch_labels)
         self.train_size = train_size
         self.seed = seed
-        self.train_query_ids = None
-        self.val_query_ids = None
-        self.x_locator = None
-        self.layer_name = kwargs.get('layer_name', 'raw')
+        self.train_query_ids: QueryIDs | None = None
+        self.val_query_ids: QueryIDs | None = None
+        self.x_locator: XLocator | None = None
+        self.layer_name = kwargs.get("layer_name", "raw")
 
     def setup(self, stage: str | None = None) -> None:
         # Create QueryIDs and XLocator from the query
@@ -120,60 +119,70 @@ class SCVIDataModule(LightningDataModule):  # type: ignore[misc]
             measurement_name=self.query.measurement_name,
             layer_name=self.layer_name,
         )
-        
+
         # Split data into train and validation sets if train_size < 1.0
         if self.train_size < 1.0:
             # Use QueryIDs.random_split() for efficient splitting
             val_size = 1.0 - self.train_size
-            self.train_query_ids, self.val_query_ids = query_ids.random_split(
+            train_ids, val_ids = query_ids.random_split(
                 self.train_size, val_size, seed=self.seed
             )
+            self.train_query_ids = train_ids
+            self.val_query_ids = val_ids
         else:
             # Use all data for training
             self.train_query_ids = query_ids
             self.val_query_ids = None
 
     def train_dataloader(self) -> DataLoader:
-        assert self.train_query_ids is not None, "setup() must be called before train_dataloader()"
-        assert self.x_locator is not None, "setup() must be called before train_dataloader()"
-        
+        assert (
+            self.train_query_ids is not None
+        ), "setup() must be called before train_dataloader()"
+        assert (
+            self.x_locator is not None
+        ), "setup() must be called before train_dataloader()"
+
         # Filter out query and layer_name from dataset_kwargs since we're using x_locator and query_ids
-        filtered_kwargs = {k: v for k, v in self.dataset_kwargs.items() 
-                          if k not in ('query', 'layer_name')}
-        
+        filtered_kwargs = {
+            k: v
+            for k, v in self.dataset_kwargs.items()
+            if k not in ("query", "layer_name")
+        }
+
         # Create dataset with train query_ids and x_locator
         train_dataset = ExperimentDataset(
             x_locator=self.x_locator,
             query_ids=self.train_query_ids,
-            obs_column_names=self.batch_column_names,  # type: ignore[arg-type]
-            *self.dataset_args,
-            **filtered_kwargs,  # type: ignore[misc]
+            obs_column_names=list(self.batch_column_names),
+            **filtered_kwargs,
         )
         return experiment_dataloader(
             train_dataset,
             **self.dataloader_kwargs,
         )
-    
+
     def val_dataloader(self) -> DataLoader | None:
-        if self.val_query_ids is not None and self.x_locator is not None:
-            # Filter out query and layer_name from dataset_kwargs since we're using x_locator and query_ids
-            filtered_kwargs = {k: v for k, v in self.dataset_kwargs.items() 
-                              if k not in ('query', 'layer_name')}
-            
-            # Create dataset with validation query_ids and x_locator
-            val_dataset = ExperimentDataset(
-                x_locator=self.x_locator,
-                query_ids=self.val_query_ids,
-                obs_column_names=self.batch_column_names,  # type: ignore[arg-type]
-                *self.dataset_args,
-                **filtered_kwargs,  # type: ignore[misc]
-            )
-            return experiment_dataloader(
-                val_dataset,
-                **self.dataloader_kwargs,
-            )
-        else:
+        if self.val_query_ids is None or self.x_locator is None:
             return None
+
+        # Filter out query and layer_name from dataset_kwargs since we're using x_locator and query_ids
+        filtered_kwargs = {
+            k: v
+            for k, v in self.dataset_kwargs.items()
+            if k not in ("query", "layer_name")
+        }
+
+        # Create dataset with validation query_ids and x_locator
+        val_dataset = ExperimentDataset(
+            x_locator=self.x_locator,
+            query_ids=self.val_query_ids,
+            obs_column_names=list(self.batch_column_names),
+            **filtered_kwargs,
+        )
+        return experiment_dataloader(
+            val_dataset,
+            **self.dataloader_kwargs,
+        )
 
     def _add_batch_col(
         self, obs_df: pd.DataFrame, inplace: bool = False


### PR DESCRIPTION
Currently, `SCVIDataModule` lacks a `val_dataloader`.

This means scVI is unable to use the `train_size: 0.9` parameter which splits the data into train and validation and allows you to log the validation loss. 

Currently, we are only able to log the train loss which is not ideal.